### PR TITLE
[FIX] Raise `BlankTitleError` if an empty, blank, or None title is passed.

### DIFF
--- a/app/task.py
+++ b/app/task.py
@@ -6,13 +6,30 @@ object has a unique ID number by using the utility class `TaskID` and its `gener
 
 Classes:
     Task: Responsible for holding task-related information such as an ID, title, due date, etc.
+    TaskError: Base `Exception` for all `Task`-related errors.
+    BlankTitleError: Raise when attempting ot set a title to None or a blank/empty string.
 """
 
-from typing import Optional
+from typing import Optional, List
 from datetime import datetime
 
 from app.task_id import TaskID
 
+
+class TaskError(Exception):
+    """Base Exception for all Task-related errors."""
+
+
+class BlankTitleError(TaskError):
+    """Raise when attempting to set a title to None or a blank/empty string.
+
+    Attributes:
+        task_id (int): The ID of the task that raised the exception.
+    """
+
+    def __init__(self, task_id: int):
+        super().__init__("Task name cannot be blank for task ID #{task_id}.")
+        self.task_id = task_id
 
 class Task:
     """Responsible for holding task-related information such as an ID, title, due date, etc.
@@ -65,6 +82,26 @@ class Task:
             int: The ID number of this task.
         """
         return self._task_id
+
+    @property
+    def title(self) -> str:
+        """Return the title of the task."""
+        return self._title
+
+    @title.setter
+    def title(self, new_title: str):
+        """Set the title of the task to a valid, non-empty string.
+
+        Args:
+            new_title (str): The new title of the task
+
+        Raises:
+            BlankTitleError: If `None` or a blank/empty string is passed.
+        """
+        if new_title is None or new_title.strip() == "":
+            raise BlankTitleError(task_id=self.task_id)
+        else:
+            self._title = new_title
 
     @property
     def status(self) -> str:

--- a/app/task.py
+++ b/app/task.py
@@ -28,7 +28,7 @@ class BlankTitleError(TaskError):
     """
 
     def __init__(self, task_id: int):
-        super().__init__("Task name cannot be blank for task ID #{task_id}.")
+        super().__init__(f"Task name cannot be blank for task ID #{task_id}.")
         self.task_id = task_id
 
 class Task:

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 import pytest
 
-from app.task import Task
+from app.task import Task, TaskError, BlankTitleError
 
 
 @pytest.mark.parametrize(
@@ -54,6 +54,42 @@ def test_task_id_immutable():
         task.task_id = 1
     except AttributeError:
         assert True
+
+
+def test_task_title_setter():
+    """Test attempting to construct and then set a task title to valid and invalid titles."""
+    valid_task_titles = [
+        "Title",
+        "1234",
+        "1",
+        "a",
+        "A longer title with some punctuation.",
+    ]
+    invalid_task_titles = [None, "", "     ", "\n", "\t"]
+
+    for valid_title in valid_task_titles:
+        # Test valid title via constructor
+        task = Task(title=valid_title)
+        assert task.title == valid_title
+
+        # Test valid title via setter
+        task = Task(title="Title")
+        task.title = valid_title
+        assert task.title == valid_title
+
+    for invalid_title in invalid_task_titles:
+        # Test invalid title via constructor
+        print(invalid_title)
+        with pytest.raises(TaskError) as e:
+            task = Task(title=invalid_title)
+            print(f"Invalid Title={invalid_title}, task={task}")
+        assert isinstance(e.value, BlankTitleError)
+
+        # Test invalid title via setter
+        task = Task(title="Title")
+        with pytest.raises(TaskError) as e:
+            task.title = invalid_title
+        assert isinstance(e.value, BlankTitleError)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## 🔄 Summary of Changes
<!-- Provide a clear and concise description of what has been changed -->

**Type of Change:** <!-- Select one -->
- **Bug Fix** 🐛

Improved the error handling and validation in the `Task` class when setting the `title` attribute. The new behavior raises a `BlankTitleError` exception when attempting to pass a `title` that is:
- Set to `None`
- Blank, empty ("")
- All whitespace or feed characters

---

## ✅ Checklist
- [x] My code follows the project's style guidelines.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my changes are effective.
- [x] All new and existing tests pass.

---

## 💬 Description
### Motivation
<!-- Explain why this change was made. Include any context or background -->
A `Task` should always have a meaningful `title`. Existing error handling allowed `None` or a blank ("") or empty ("    ") title to be set during both `__init__()` and via the `@setter`. The proposed changes raise an exception if an invalid title is passed to the `Task`.


### Proposed Solution
<!-- Explain the solution and why it solves the problem -->

- Add an `@property` decorator for returning the `title` string when called.
- Add an `@setter` decorator to perform a simple check on the `title` attribute being passed.
  - If it is invalid, raise `BlankTitleError` exception.
  - If it is valid, update the title.
- Require `__init__()` to use the `@setter` for `title`
- Add `Exceptions`
  - `TaskError`: Base `Exception` for all `Task`-related errors.
  - `BlankTitleError`: Raise when attempting to set a title to None or a blank/empty string.

---

## 🧪 Testing
<!-- Explain what kind of testing has been done (e.g., unit, integration) -->

- **Test Cases:**
  1. **Case 1:** Task Title Setter
    - Steps:
      - Test task construction (calls setter) and setter with valid titles.
      - Test task construction and setter with invalid titles.
    - Expected Behavior:
      - The task title matches the title passed if the new title is valid.
      - Raise `EmptyTitleError` when an invalid title is passed.

### Test Environment
- **OS:** <!-- e.g., Windows 10 / macOS Monterey / Ubuntu 20.04 --> Ubuntu 22.04 (via WSL2 on Windows 11)
- **Python Version:** <!-- e.g., Python 3.10 --> Python 3.13.0

---

## 📎 Related Issues
- Closes #5 

---

**Additional Notes**
<!-- Add any other relevant information about the PR here -->
> [!NOTE]
> The following are considered invalid titles when set to:
> - NoneType: `None`
> - An empty string:  `""`
> - A blank string: `"     "`
> - A string of non-printing characters:  `"\n \t"`