### PR TITLE
[REFACTOR] Rename `TaskManager` to `TaskList` (including class, module, and all related references)

### DIFF
--- a/app/task_list.py
+++ b/app/task_list.py
@@ -1,15 +1,15 @@
 """
-Task Manager Module
+Task List Module
 
 Responsible for CRUD operations required to create and manage list of `Task` objects.
 
 Classes:
-    TaskManager: Handle CRUD operations for `Task` objects and keep a list of tasks.
-    TaskManagerError(Exception): Base exception for Task Manager errors.
-    EmptyTaskListError(TaskManagerError): Raise when trying to perform operations on an empty task
+    TaskList: Handle CRUD operations for `Task` objects and keep a list of tasks.
+    TaskListError(Exception): Base exception for Task List errors.
+    EmptyTaskListError(TaskListError): Raise when trying to perform operations on an empty task
         list.
-    TaskNotFoundError(TaskManagerError): Raise when a specific task is not found in the task list.
-    AddDuplicateTaskError(TaskManagerError): Raise when trying to add a task already present in the
+    TaskNotFoundError(TaskListError): Raise when a specific task is not found in the task list.
+    AddDuplicateTaskError(TaskListError): Raise when trying to add a task already present in the
         task list.
 """
 
@@ -18,11 +18,11 @@ from typing import Optional, List, Union
 from app.task import Task
 
 
-class TaskManagerError(Exception):
-    """Base exception for Task Manager errors."""
+class TaskListError(Exception):
+    """Base exception for Task List errors."""
 
 
-class EmptyTaskListError(TaskManagerError):
+class EmptyTaskListError(TaskListError):
     """Raise when trying to perform operations on an empty task list."""
 
     def __init__(self, method_name: Optional[str] = None):
@@ -33,7 +33,7 @@ class EmptyTaskListError(TaskManagerError):
         self.operation = method_name
 
 
-class TaskNotFoundError(TaskManagerError):
+class TaskNotFoundError(TaskListError):
     """Raise when a specific task is not found in the task list."""
 
     def __init__(self, task_id: int):
@@ -41,7 +41,7 @@ class TaskNotFoundError(TaskManagerError):
         self.task_id = task_id
 
 
-class AddDuplicateTaskError(TaskManagerError):
+class AddDuplicateTaskError(TaskListError):
     """Raise when trying to add a task already present in the task list."""
 
     def __init__(self, task: str):
@@ -52,11 +52,11 @@ class AddDuplicateTaskError(TaskManagerError):
         self.task_title = task.title
 
 
-class TaskManager:
+class TaskList:
     """Handle CRUD operations for `Task` objects and keep a list of tasks.
 
     Attributes:
-        task_list (List[Task]): A list of `Task` objects that belong to this `TaskManager`
+        task_list (List[Task]): A list of `Task` objects that belong to this `TaskList`
 
     Methods:
         add_task: Add a `Task` obj to the list if is not already in the list.
@@ -66,11 +66,11 @@ class TaskManager:
     """
 
     def __init__(self, task_list: Optional[List[Task]] = None):
-        """Construct the `TaskManager` object with a task list.
+        """Construct the `TaskList` object with a task list.
 
         Args:
             task_list (Optional[List[Task]], optional): The lists of tasks held by this
-                `TaskManager`. Defaults to None.
+                `TaskList`. Defaults to None.
         """
         self.task_list: List[Task] = task_list if task_list else []
 
@@ -97,7 +97,7 @@ class TaskManager:
         Raises:
             EmptyTaskListError: if the task_list is empty.
             TaskNotFoundError: if a `Task` with a matching `task_id` value is not found in the
-                task manager's list.
+                task list.
 
         Returns:
             Task: The matching `Task` object.
@@ -127,14 +127,16 @@ class TaskManager:
         Raises:
             EmptyTaskListError: if the task_list is empty.
             TaskNotFoundError: if a `Task` with a matching `task_id` value is not found in the
-                task manager's list.
+                task list.
         """
         task_id = task if isinstance(task, int) else task.task_id
         if self.task_list:
             task = self.get_task(task_id=task_id)
             self.task_list.remove(task)
         else:
-            raise EmptyTaskListError(method_name=f"`delete_task()` for `task_id` == {task_id}")
+            raise EmptyTaskListError(
+                method_name=f"`delete_task()` for `task_id` == {task_id}"
+            )
 
     def __str__(self):
         """Return a user-friendly string representation of the task.
@@ -151,7 +153,7 @@ class TaskManager:
             - No tasks in the task list.
 
         Returns:
-            str: A brief representation of the task manager/task list.
+            str: A brief representation of the task list/task list.
         """
         list_str = "Task List:\n"
         if self.task_list:
@@ -165,12 +167,12 @@ class TaskManager:
         """Return a string representation of all tasks and their attributes present in the list.
 
         The string includes the complete task list and child task attributes in the format:
-            <TaskManager: task_list=[<Task: ...>, <Task: ...>]>
+            <TaskList: task_list=[<Task: ...>, <Task: ...>]>
 
         Returns:
-            str: A complete representation of the task manager/task list.
+            str: A complete representation of the task list/task list.
         """
         task_list = []
         for task in self.get_all_tasks():
             task_list.append(f"{task!r}")
-        return f"<TaskManager: task_list={task_list}>"
+        return f"<TaskList: task_list={task_list}>"

--- a/main.py
+++ b/main.py
@@ -4,20 +4,20 @@ A C.R.U.D.dy To-Do List
 """
 
 from app.task import Task
-from app.task_manager import TaskManager
+from app.task_list import TaskList
 
 if __name__ == "__main__":
 
-    task_manager = TaskManager()
-    print(task_manager)
-    print(f"{task_manager!r}")
+    task_list = TaskList()
+    print(task_list)
+    print(f"{task_list!r}")
     task = Task("title")
     task1 = Task("title1")
     task2 = Task("title2")
     task3 = Task("title3")
-    task_manager.add_task(task)
-    task_manager.add_task(task1)
-    task_manager.add_task(task2)
-    task_manager.add_task(task3)
-    print(task_manager)
-    print(f"{task_manager!r}")
+    task_list.add_task(task)
+    task_list.add_task(task1)
+    task_list.add_task(task2)
+    task_list.add_task(task3)
+    print(task_list)
+    print(f"{task_list!r}")

--- a/tests/test_task_list.py
+++ b/tests/test_task_list.py
@@ -1,3 +1,7 @@
+"""
+Task List Testing Module
+"""
+
 import pytest
 
 from app.task import Task
@@ -15,23 +19,23 @@ def test_task_list_constructor():
     task_list = TaskList()
     assert not task_list.task_list
 
-    task_list = [Task("task 1"), Task("task 2"), Task("task 3")]
-    task_list = TaskList(task_list=task_list)
-    assert task_list.task_list == task_list
+    list_of_tasks = [Task("task 1"), Task("task 2"), Task("task 3")]
+    task_list = TaskList(task_list=list_of_tasks)
+    assert task_list.task_list == list_of_tasks
 
 
 def test_add_task():
     """Test adding multiple new (valid) and duplicate (invalid) tasks."""
     task_list = TaskList()
-    task_list = [Task("task 1"), Task("task 2"), Task("task 3")]
+    list_of_tasks = [Task("task 1"), Task("task 2"), Task("task 3")]
 
     # Add the tasks the first time
-    for task in task_list:
+    for task in list_of_tasks:
         task_list.add_task(task)
-    assert task_list.task_list == task_list
+    assert task_list.task_list == list_of_tasks
 
     # Try adding them again (error state)
-    for task in task_list:
+    for task in list_of_tasks:
         with pytest.raises(TaskListError) as e:
             task_list.add_task(task)
         assert isinstance(e.value, AddDuplicateTaskError)
@@ -42,8 +46,8 @@ def test_get_task():
     the list is empty (invalid).
     """
     task_list = TaskList()
-    task_list = [Task("task 1"), Task("task 2"), Task("task 3")]
-    valid_id = task_list[0].task_id
+    list_of_tasks = [Task("task 1"), Task("task 2"), Task("task 3")]
+    valid_id = list_of_tasks[0].task_id
     invalid_id = Task("Not Added").task_id
 
     # Try to get a task from an empty list (error state)
@@ -55,7 +59,7 @@ def test_get_task():
     assert isinstance(e.value, EmptyTaskListError)
 
     # Get an existing task from the list.
-    task_list = TaskList(task_list=task_list)
+    task_list = TaskList(task_list=list_of_tasks)
     assert task_list.get_task(valid_id).task_id == valid_id
 
     # Try to get a task that does not exist in the list.
@@ -69,9 +73,9 @@ def test_get_all_tasks():
     task_list = TaskList()
     assert not task_list.get_all_tasks()
 
-    task_list = [Task("task 1"), Task("task 2"), Task("task 3")]
-    task_list = TaskList(task_list=task_list)
-    assert task_list.get_all_tasks() == task_list
+    list_of_tasks = [Task("task 1"), Task("task 2"), Task("task 3")]
+    task_list = TaskList(task_list=list_of_tasks)
+    assert task_list.get_all_tasks() == list_of_tasks
 
 
 def test_delete_task():
@@ -79,9 +83,9 @@ def test_delete_task():
     the list is empty (invalid).
     """
     task_list = TaskList()
-    task_list = [Task("task 1"), Task("task 2"), Task("task 3")]
-    valid_task = task_list[-1]
-    valid_id = task_list[0].task_id
+    list_of_tasks = [Task("task 1"), Task("task 2"), Task("task 3")]
+    valid_task = list_of_tasks[-1]
+    valid_id = list_of_tasks[0].task_id
     invalid_task = Task("Not Added")
     invalid_id = invalid_task.task_id
 
@@ -95,7 +99,7 @@ def test_delete_task():
     assert isinstance(e.value, EmptyTaskListError)
 
     # Delete an existing task from the list by ID and by a `Task` object
-    task_list = TaskList(task_list=task_list)
+    task_list = TaskList(task_list=list_of_tasks)
     task_list.delete_task(task=valid_id)
     task_list.delete_task(task=valid_task)
 

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -1,39 +1,39 @@
 import pytest
 
 from app.task import Task
-from app.task_manager import (
+from app.task_list import (
     AddDuplicateTaskError,
     EmptyTaskListError,
-    TaskManager,
-    TaskManagerError,
+    TaskList,
+    TaskListError,
     TaskNotFoundError,
 )
 
 
-def test_task_manager_constructor():
+def test_task_list_constructor():
     "Test basic construction with and without a task list provided."
-    task_manager = TaskManager()
-    assert not task_manager.task_list
+    task_list = TaskList()
+    assert not task_list.task_list
 
     task_list = [Task("task 1"), Task("task 2"), Task("task 3")]
-    task_manager = TaskManager(task_list=task_list)
-    assert task_manager.task_list == task_list
+    task_list = TaskList(task_list=task_list)
+    assert task_list.task_list == task_list
 
 
 def test_add_task():
     """Test adding multiple new (valid) and duplicate (invalid) tasks."""
-    task_manager = TaskManager()
+    task_list = TaskList()
     task_list = [Task("task 1"), Task("task 2"), Task("task 3")]
 
     # Add the tasks the first time
     for task in task_list:
-        task_manager.add_task(task)
-    assert task_manager.task_list == task_list
+        task_list.add_task(task)
+    assert task_list.task_list == task_list
 
     # Try adding them again (error state)
     for task in task_list:
-        with pytest.raises(TaskManagerError) as e:
-            task_manager.add_task(task)
+        with pytest.raises(TaskListError) as e:
+            task_list.add_task(task)
         assert isinstance(e.value, AddDuplicateTaskError)
 
 
@@ -41,44 +41,44 @@ def test_get_task():
     """Test getting a task from a task list when it exists (valid), does not exists (invalid), and
     the list is empty (invalid).
     """
-    task_manager = TaskManager()
+    task_list = TaskList()
     task_list = [Task("task 1"), Task("task 2"), Task("task 3")]
     valid_id = task_list[0].task_id
     invalid_id = Task("Not Added").task_id
 
     # Try to get a task from an empty list (error state)
-    with pytest.raises(TaskManagerError) as e:
-        task_manager.get_task(valid_id)
+    with pytest.raises(TaskListError) as e:
+        task_list.get_task(valid_id)
     assert isinstance(e.value, EmptyTaskListError)
-    with pytest.raises(TaskManagerError) as e:
-        task_manager.get_task(invalid_id)
+    with pytest.raises(TaskListError) as e:
+        task_list.get_task(invalid_id)
     assert isinstance(e.value, EmptyTaskListError)
 
     # Get an existing task from the list.
-    task_manager = TaskManager(task_list=task_list)
-    assert task_manager.get_task(valid_id).task_id == valid_id
+    task_list = TaskList(task_list=task_list)
+    assert task_list.get_task(valid_id).task_id == valid_id
 
     # Try to get a task that does not exist in the list.
-    with pytest.raises(TaskManagerError) as e:
-        task_manager.get_task(invalid_id)
+    with pytest.raises(TaskListError) as e:
+        task_list.get_task(invalid_id)
     assert isinstance(e.value, TaskNotFoundError)
 
 
 def test_get_all_tasks():
     """Test getting all tasks from  a populated and an empty task list"""
-    task_manager = TaskManager()
-    assert not task_manager.get_all_tasks()
+    task_list = TaskList()
+    assert not task_list.get_all_tasks()
 
     task_list = [Task("task 1"), Task("task 2"), Task("task 3")]
-    task_manager = TaskManager(task_list=task_list)
-    assert task_manager.get_all_tasks() == task_list
+    task_list = TaskList(task_list=task_list)
+    assert task_list.get_all_tasks() == task_list
 
 
 def test_delete_task():
     """Test getting a task from a task list when it exists (valid), does not exists (invalid), and
     the list is empty (invalid).
     """
-    task_manager = TaskManager()
+    task_list = TaskList()
     task_list = [Task("task 1"), Task("task 2"), Task("task 3")]
     valid_task = task_list[-1]
     valid_id = task_list[0].task_id
@@ -86,24 +86,24 @@ def test_delete_task():
     invalid_id = invalid_task.task_id
 
     # Try to delete a task from an empty list (error state)
-    with pytest.raises(TaskManagerError) as e:
-        task_manager.delete_task(valid_id)
+    with pytest.raises(TaskListError) as e:
+        task_list.delete_task(valid_id)
     assert isinstance(e.value, EmptyTaskListError)
 
-    with pytest.raises(TaskManagerError) as e:
-        task_manager.delete_task(invalid_id)
+    with pytest.raises(TaskListError) as e:
+        task_list.delete_task(invalid_id)
     assert isinstance(e.value, EmptyTaskListError)
 
     # Delete an existing task from the list by ID and by a `Task` object
-    task_manager = TaskManager(task_list=task_list)
-    task_manager.delete_task(task=valid_id)
-    task_manager.delete_task(task=valid_task)
+    task_list = TaskList(task_list=task_list)
+    task_list.delete_task(task=valid_id)
+    task_list.delete_task(task=valid_task)
 
     # Try to get a task that does not exist in the list.
-    with pytest.raises(TaskManagerError) as e:
-        task_manager.delete_task(invalid_id)
+    with pytest.raises(TaskListError) as e:
+        task_list.delete_task(invalid_id)
     assert isinstance(e.value, TaskNotFoundError)
 
-    with pytest.raises(TaskManagerError) as e:
-        task_manager.delete_task(invalid_task)
+    with pytest.raises(TaskListError) as e:
+        task_list.delete_task(invalid_task)
     assert isinstance(e.value, TaskNotFoundError)


### PR DESCRIPTION
# [REFACTOR] Rename `TaskManager` class, module, and all related references to `TaskList` (including variable names and variations)

## 🔄 Summary of Changes
<!-- Provide a clear and concise description of what has been changed -->
`TaskManager` class has been renamed to `TaskList`. Its module name has been updated, and similarly named variables have been updated (such as `task_manager` becoming `task_list`). Documentation and testing have been updated.

---

## ✅ Checklist
- [x] My code follows the project's style guidelines.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my changes are effective.
- [x] All new and existing tests pass.

---

## 💬 Description
### Motivation
<!-- Explain why this change was made. Include any context or background -->
`TaskManager` should be renamed to `TaskList` to better reflect how it handles CRUD operations over the list of tasks itself. This allows a new `TaskManager` class to handle CRUD operations for `Task` objects in a separate issue. 


### Proposed Solution
<!-- Explain the solution and why it solves the problem -->
| Type | Old | New|
|--------|--------|--------|
| Module Name: | `task_manager.py` | `task_list.py`|
| Module Name: | `test_task_manager.py` | `test_task_list.py`|
| Class Name: | `TaskManager` | `TaskList`|
| Exception Name: | `TaskManagerError` | `TaskListError`|
---

## 🧪 Testing
<!-- Explain what kind of testing has been done (e.g., unit, integration) -->

- Only name and reference updates were required. No new tests.

### Test Environment
- **OS:** <!-- e.g., Windows 10 / macOS Monterey / Ubuntu 20.04 --> Ubuntu 22.04 (via WSL2 on Windows 11)
- **Python Version:** <!-- e.g., Python 3.10 --> Python 3.13.0

---

## 📎 Related Issues
Closes #24 

---

**Additional Notes**
<!-- Add any other relevant information about the PR here -->
